### PR TITLE
add DateInput component

### DIFF
--- a/src/components/form-elements/DateInput.jsx
+++ b/src/components/form-elements/DateInput.jsx
@@ -36,7 +36,7 @@ const DateInput = React.createClass({
 		if (values[1] > 0)
 			values[1] = values[1] - 1
 
-		return new (Function.prototype.bind.apply(Date, [null].concat(values)))
+		return new Date(Date.UTC.apply(Date, values))
 	},
 
 	handleBlur: function () {

--- a/src/components/form-elements/__tests__/DateInput-test.jsx
+++ b/src/components/form-elements/__tests__/DateInput-test.jsx
@@ -15,9 +15,9 @@ describe('<DateInput />', function () {
 		const d = new Date()
 		const value = d.toISOString()
 
-		const year = d.getFullYear()
-		let month = (d.getMonth() + 1) + ''
-		let day = d.getDate() + ''
+		const year = d.getUTCFullYear()
+		let month = (d.getUTCMonth() + 1) + ''
+		let day = d.getUTCDate() + ''
 
 		if (month.length === 1)
 			month = '0' + month
@@ -37,9 +37,9 @@ describe('<DateInput />', function () {
 
 		const onChange = (val) => {
 			expect(val).to.be.an.instanceOf(Date)
-			expect(val.getFullYear()).to.equal(split[0])
-			expect(val.getMonth()).to.equal(split[1] - 1)
-			expect(val.getDate()).to.equal(split[2])
+			expect(val.getUTCFullYear()).to.equal(split[0])
+			expect(val.getUTCMonth()).to.equal(split[1] - 1)
+			expect(val.getUTCDate()).to.equal(split[2])
 			done()
 		}
 
@@ -53,9 +53,9 @@ describe('<DateInput />', function () {
 		const split = update.split('-').map(Number)
 
 		const onChange = (val) => {
-			expect(val.getFullYear()).to.equal(split[0])
-			expect(val.getMonth()).to.equal(split[1] - 1)
-			expect(val.getDate()).to.equal(split[2])
+			expect(val.getUTCFullYear()).to.equal(split[0])
+			expect(val.getUTCMonth()).to.equal(split[1] - 1)
+			expect(val.getUTCDate()).to.equal(split[2])
 			done()
 		}
 


### PR DESCRIPTION
This adds a `<DateInput />` component to the form elements family. The value passed when `onChange` is called is an ISO formatted datetime string.

Closes #15 