### PR TITLE
always search when SearchWrapper mounts w/ a query string

### DIFF
--- a/src/pages/SearchWrapper.jsx
+++ b/src/pages/SearchWrapper.jsx
@@ -21,7 +21,7 @@ const SearchWrapper = React.createClass({
 	componentWillMount: function () {
 		const qs = this.props.location.search
 
-		if (qs && !this.props.search.query)
+		if (qs)
 			this.props.searchCatalogByQueryString(qs).then(this.handleSearchResponse)
 	},
 


### PR DESCRIPTION
This resolves #30 but also raises/begins the epic found in #50. 

fixes #30 