### PR TITLE
prevent accidentally clearing facets from SearchFacetSidebar form

### DIFF
--- a/lib/format-search-querystring.js
+++ b/lib/format-search-querystring.js
@@ -42,10 +42,13 @@ export default function formatSearchQuerystring (query, facets, options) {
 		}
 	})
 
-	return stringify({
+	const toStringify = {
 		options: opts,
 		facets: mappedFacets,
 		query,
-	})
+	}
+
+	const strung = stringify(toStringify)
+	return strung
 }
 

--- a/src/components/catalog/SearchFacetSidebar.jsx
+++ b/src/components/catalog/SearchFacetSidebar.jsx
@@ -31,7 +31,6 @@ const SearchFacetSidebar = React.createClass({
 
 	handleClearFacets: function (ev) {
 		ev.preventDefault && ev.preventDefault()
-
 		this.props.onClearSelectedFacets()
 	},
 
@@ -72,8 +71,8 @@ const SearchFacetSidebar = React.createClass({
 						style={styles.input}
 						type="search"
 					/>
-					{button}
 				</form>
+				{button}
 			</div>
 		)
 	},

--- a/src/pages/SearchResults.jsx
+++ b/src/pages/SearchResults.jsx
@@ -120,11 +120,10 @@ const SearchResults = React.createClass({
 	},
 
 	handleSubmitSearchQuery: function (query) {
-		this.props.searchCatalog(
-			query,
-			this.props.search.facets,
-			this.props.search.options
-		).then(this.handleSearchResponse)
+		const { facets, options } = this.props.search
+
+		this.props.searchCatalog(query, facets, options)
+		.then(this.handleSearchResponse)
 	},
 
 	maybeRenderLoadingModal: function () {


### PR DESCRIPTION
found this one while investigating #4. from the commit:

> this fixes a bug where submitting the search form on SearchFacetSidebar
> was triggering the 'Clear Facets' button by moving the button outside of
> the `<form>` component. there is also some code cleanup that was a
> result of the hunt for the problem.

to reproduce the bug:

1. visit `/search` page + conduct a search
2. select a facet
3. enter new search term in `SearchFacetSidebar` input (or focus on element and press `enter`)
4. gasp at the fact that your facet has been removed