### PR TITLE
add link to search in navbar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -12,6 +12,12 @@ const Navbar = React.createClass({
 				<nav className="site-navigation">
 					<ul>
 						<li>
+							<Link to="/search">
+								Search
+							</Link>
+						</li>
+
+						<li>
 							<Link to="/vocabularies">
 								Vocabulary Manager
 							</Link>

--- a/src/scss/_navbar.scss
+++ b/src/scss/_navbar.scss
@@ -26,6 +26,10 @@
 			list-style-type: none;
 			margin: 0;
 			padding: 0;
+
+			&:not(:first-of-type) {
+				margin-left: 1em;
+			}
 		}
 	}
 


### PR DESCRIPTION
![screen shot 2016-12-05 at 9 41 36 am](https://cloud.githubusercontent.com/assets/2744987/20888960/1e339f42-bacf-11e6-99fd-460e67712ddf.png)

this adds a link to `/search` in the navbar, so we don't have to keep manually navigating there for testing.
