### PR TITLE
use empty string instead of null for DateInput

### DIFF
--- a/src/components/metadata/DateInput.jsx
+++ b/src/components/metadata/DateInput.jsx
@@ -19,7 +19,7 @@ const DateInput = React.createClass({
 		const value = this.props.value
 
 		if (!value)
-			return { date: null }
+			return { date: '' }
 
 		// `time` will either be `HH:MM:SS.000Z`
 		// or undefined (if short date (YYYY-MM-DD) is passed)


### PR DESCRIPTION
Fixes #90, where React would complain about the `input` element within `DateInput` receiving a null value.