### PR TITLE
Fix selected facet group

### DIFF
--- a/src/components/catalog/Facet.jsx
+++ b/src/components/catalog/Facet.jsx
@@ -114,7 +114,7 @@ const Facet = React.createClass({
 
 	getInitialState: function () {
 		return {
-			open: this.props.open,
+			open: this.props.open || this.props.selectedFacets.length > 0,
 		}
 	},
 


### PR DESCRIPTION
A bug fix + a small feature enhancement: Facets containing selected items will now have a matching green header and will be open by default. The latter was an enhancement for the LDR that I wanted to incorporate.

Fixes #114