### PR TITLE
Add ResultsTable overflow scrolling

### DIFF
--- a/src/components/catalog/ResultsTable.jsx
+++ b/src/components/catalog/ResultsTable.jsx
@@ -216,12 +216,14 @@ class ResultsTable extends React.Component {
 
 	render () {
 		return (
-			<TacoTable
-				className="results-table"
-				columns={this.getColumns()}
-				data={this.props.data}
-				sortable={false}
-				/>
+			<div className="results-table-container">
+				<TacoTable
+					className="results-table"
+					columns={this.getColumns()}
+					data={this.props.data}
+					sortable={false}
+					/>
+			</div>
 		)
 	}
 }

--- a/src/scss/catalog/_results-table.scss
+++ b/src/scss/catalog/_results-table.scss
@@ -1,5 +1,11 @@
 // src/components/catalog/ResultsTable.jsx
+.results-table-container {
+	overflow-x: scroll;
+}
+
 .results-table {
+	$thumbnail-size: 175px;
+
 	margin-top: 1em;
 	min-width: 100%;
 
@@ -14,17 +20,15 @@
 	}
 
 	td {
+		min-width: $thumbnail-size;
 		padding: 1em;
 	}
 
 	td.thumbnail-preview {
-		$thumbnail-size: 175px;
-
 		background-color: #eee;
 		height: $thumbnail-size;
 		padding: 1em;
 		text-align: center;
-		width: $thumbnail-size;
 
 		img {
 			max-height: 100%;


### PR DESCRIPTION
This sets a minimum width for the ResultsTable cells (175px, thumbnail
size) and sets the container to allow scrolling for overflowing content.
Previously, a table cell's width was NUMBER_OF_ROWS / 100, which resulted
in cramped cells when many rows were selected.

![table-overflow-scroll-pr](https://cloud.githubusercontent.com/assets/2744987/22338164/b24e9534-e3b4-11e6-9dd4-6c8ee3dd760b.gif)
