### PR TITLE
add Select All option for Search Result Table Fields

### DIFF
--- a/src/components/catalog/ResultsTable.jsx
+++ b/src/components/catalog/ResultsTable.jsx
@@ -32,12 +32,13 @@ const defaultProps = {
 // create a dictionary to use for sorting the fields based on position.
 // this way, the fields remain in the order displayed in the
 // `ResultsTableFieldSelect` component
-const workFieldKeys = Object.keys(workFields).reduce((dict, key, index) => {
+const workFieldKeys = Object.keys(workFields)
+const workFieldSortDict = workFieldKeys.reduce((dict, key, index) => {
 	dict[key] = index + 1
 	return dict
 }, {})
 
-const sortByField = (a, b) => (workFieldKeys[a] - workFieldKeys[b])
+const sortByField = (a, b) => (workFieldSortDict[a] - workFieldSortDict[b])
 
 const ResultsTable = React.createClass({
 	propTypes: propTypes,
@@ -195,9 +196,14 @@ const ResultsTable = React.createClass({
 			this.setFields(this.props.defaultFields)
 		}
 
+		const onSelectAll = () => {
+			this.setFields(workFieldKeys)
+		}
+
 		const props = {
 			onClose,
 			onReset,
+			onSelectAll,
 			fields: workFields,
 			key: 'field-select',
 			onSelectField: this.handleOnSelectField,

--- a/src/components/catalog/ResultsTableFieldSelect.jsx
+++ b/src/components/catalog/ResultsTableFieldSelect.jsx
@@ -42,6 +42,10 @@ const ResultsTableFieldSelect = React.createClass({
 		this.props.onReset && this.props.onReset()
 	},
 
+	handleSelectAll: function () {
+		this.props.onSelectAll && this.props.onSelectAll()
+	},
+
 	maybeCloseSelect: function (event) {
 		let target = event.target
 
@@ -68,7 +72,10 @@ const ResultsTableFieldSelect = React.createClass({
 
 	renderWorkFields: function () {
 		const header = [
-			(<div className="field field-header" key="header" onClick={this.handleReset}>
+			(<div className="field field-header" key="all" onClick={this.handleSelectAll}>
+				Select all fields
+			</div>),
+			(<div className="field field-header" key="restore" onClick={this.handleReset}>
 				Restore defaults
 			</div>),
 			(<div className="field-divider" key="divider"/>),


### PR DESCRIPTION
This adds the ability to select all fields on the Search Results table.

(This also reverts `ResultsTable` and `ResultsTableFieldSelect` to the `React.createClass` pattern for consistency's sake.)

Closes #130 

![select-all-table-fields](https://cloud.githubusercontent.com/assets/2744987/23227891/8e39559e-f908-11e6-84aa-cff7281763b8.gif)
