### PR TITLE
Fix RangeSliderDate date selection problem

### DIFF
--- a/src/components/catalog/RangeSliderDate.jsx
+++ b/src/components/catalog/RangeSliderDate.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import Button from '../Button.jsx'
 import Slider from 'rc-slider'
+
+import DelayedInput from '../metadata/DelayedInput.jsx'
+import Button from '../Button.jsx'
 
 import formatDateValue from './common/format-date-value'
 import roundDateValue from './common/round-date-to-interval'
@@ -105,9 +107,7 @@ class RangeSliderDate extends React.Component {
 		this.props.onApplyRange(value)
 	}
 
-	handleInputChange (which, event) {
-		const target = (event || {}).target || {}
-		const value = target.value
+	handleInputChange (which, value) {
 		const parsed = parseInputValue(value)
 
 		const update = {}
@@ -120,22 +120,21 @@ class RangeSliderDate extends React.Component {
 	renderInput (which) {
 		const tsValue = this.state[which]
 		const value = tsValue ? formatDateValue(this.props.interval, tsValue) : ''
-		const type = getInputType(this.props.interval)
 
 		const props = {
 			className: 'range-slider-date--input',
 			key: `input-${which}`,
 			min: this._formatted.min,
 			max: this._formatted.max,
-			onChange: this.handleInputChange.bind(this, which),
-			type,
+			onChange: ev => this.handleInputChange(which, ev),
+			type: getInputType(this.props.interval),
 			value,
 		}
 
 		return (
 			<label className="range-slider-date--label">
 				{which}
-				<input {...props} />
+				<DelayedInput {...props} />
 			</label>
 		)
 	}

--- a/src/components/catalog/__tests__/RangeSliderDate-test.jsx
+++ b/src/components/catalog/__tests__/RangeSliderDate-test.jsx
@@ -19,22 +19,19 @@ const shallowEl = xtend => wrapper(xtend, shallow)
 
 describe('<RangeSliderDate />', function () {
 	describe('when interval="month"', function () {
-		const sel = 'input[type="month"]'
-		let $el
+		let $els
 
 		beforeEach(function () {
-			$el = shallowEl({interval: INTERVALS.MONTH })
+			const $el = shallowEl({interval: INTERVALS.MONTH })
+			$els = $el.find('DelayedInput')
 		})
 
 		it('renders inputs with `type="month"', function () {
-			const $els = $el.find(sel)
-
+			const $filtered = $els.findWhere($e => $e.prop('type') === 'month')
 			expect($els).to.have.length(2)
 		})
 
 		it('parses value to YYYY-MM', function () {
-			const $els = $el.find(sel)
-
 			$els.forEach($$el => {
 				expect($$el.prop('value')).to.match(/^\d{4}-\d{2}$/)
 			})
@@ -42,20 +39,19 @@ describe('<RangeSliderDate />', function () {
 	})
 
 	describe('when interval="day"', function () {
-		const sel = 'input[type="date"]'
-		let $el
+		let $els
 
 		beforeEach(function () {
-			$el = shallowEl({interval: INTERVALS.DAY})
+			const $el = shallowEl({interval: INTERVALS.DAY})
+			$els = $el.find('DelayedInput')
 		})
 
 		it('renders inputs with `type="date"`', function () {
-			const $els = $el.find(sel)
+			const $filtered = $els.findWhere($e => $e.prop('type') === 'date')
 			expect($els).to.have.length(2)
 		})
 
 		it('parses value to YYYY-MM-DD', function () {
-			const $els = $el.find(sel)
 			$els.forEach($$el => {
 				expect($$el.prop('value')).to.match(/^\d{4}-\d{2}-\d{2}$/)
 			})
@@ -63,20 +59,19 @@ describe('<RangeSliderDate />', function () {
 	})
 
 	describe('when interval="year"', function () {
-		const sel = 'input[type="number"]'
-		let $el
+		let $els
 
 		beforeEach(function () {
-			$el = shallowEl({interval: INTERVALS.YEAR})
+			const $el = shallowEl({interval: INTERVALS.YEAR})
+			$els = $el.find('DelayedInput')
 		})
 
 		it('renders inputs with `type="number"`', function () {
-			const $els = $el.find(sel)
+			const $filtered = $els.findWhere($e => $e.prop('type') === 'number')
 			expect($els).to.have.length(2)
 		})
 
 		it('parses value to YYYY', function () {
-			const $els = $el.find(sel)
 			$els.forEach($$el => {
 				expect($$el.prop('value')).to.match(/^\d{4}$/)
 			})
@@ -149,13 +144,13 @@ describe('<RangeSliderDate />', function () {
 			const minTs = Date.UTC.apply(Date, split)
 			const $el = shallowEl({interval: INTERVALS.DAY})
 
-			const $min = $el.find('input[type="date"]').filterWhere(el => (
+			const $min = $el.find('DelayedInput').filterWhere(el => (
 				el.key() === 'input-min'
 			))
 
 			expect($min).to.have.length(1)
 
-			$min.simulate('change', {target: {value: minValue}})
+			$min.simulate('change', minValue)
 
 			const minState = $el.state('min')
 			expect(minState).to.equal(minTs)
@@ -171,13 +166,13 @@ describe('<RangeSliderDate />', function () {
 			const maxTs = Date.UTC.apply(Date, split)
 			const $el = shallowEl({interval: INTERVALS.DAY})
 
-			const $max = $el.find('input[type="date"]').filterWhere(el => (
+			const $max = $el.find('DelayedInput').filterWhere(el => (
 				el.key() === 'input-max'
 			))
 
 			expect($max).to.have.length(1)
 
-			$max.simulate('change', {target: {value: maxValue}})
+			$max.simulate('change', maxValue)
 
 			const maxState = $el.state('max')
 			expect(maxState).to.equal(maxTs)

--- a/src/components/metadata/DelayedInput.jsx
+++ b/src/components/metadata/DelayedInput.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+const DelayedInput = React.createClass({
+	getInitialState: function () {
+		return {
+			value: this.props.value || '',
+		}
+	},
+
+	componentWillReceiveProps: function (nextProps) {
+		if (nextProps.value !== this.state.value) {
+			this.setState({value: nextProps.value})
+		}
+	},
+
+	onBlur: function (ev) {
+		this.props.onBlur && this.props.onBlur(ev)
+		this.props.onChange && this.props.onChange(this.state.value)
+	},
+
+	onChange: function (ev) {
+		this.setState({value: ev.target.value})
+	},
+
+	render: function () {
+		return (
+			<input
+				{ ...this.props }
+
+				onBlur={this.onBlur}
+				onChange={this.onChange}
+				value={this.state.value}
+			/>
+		)
+	}
+})
+
+export default DelayedInput


### PR DESCRIPTION
We ran into a problem with RangeSliderDate where attempting to
change the year caused issues with the date parsing happening
on each `onChange` event which was fired. This creates a new
`DelayedInput` component which only triggers `onChange` when
`onBlur` is called.

In a future refactor, we should use this component in `StringInput`
since the same thing is going on there. Ditto `DateInput`.